### PR TITLE
seciont62

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type Server struct {
+	srv *http.Server
+	l   net.Listener
+}
+
+func NewServer(l net.Listener, mux http.Handler) *Server {
+	return &Server{
+		l: l,
+		srv: &http.Server{
+			Handler: mux,
+		},
+	}
+}
+
+func (s *Server) Run(ctx context.Context) error {
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		if err := s.srv.Serve(s.l); err != nil && err != http.ErrServerClosed {
+			log.Printf("failed to close: %+v", err)
+			return err
+		}
+		return nil
+	})
+
+	<-ctx.Done()
+	if err := s.srv.Shutdown(context.Background()); err != nil {
+		log.Printf("failed to shutdown: %+v", err)
+	}
+
+	return eg.Wait()
+}

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func TestServer_Run(t *testing.T) {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen port %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	eg, ctx := errgroup.WithContext(ctx)
+	mux := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
+	})
+	eg.Go(func() error {
+		s := NewServer(l, mux)
+		return s.Run(ctx)
+	})
+	in := "message"
+	url := fmt.Sprintf("http://%s/%s", l.Addr().String(), in)
+	t.Logf("try request to %q", url)
+	res, err := http.Get(url)
+	if err != nil {
+		t.Errorf("failed to get: %+v", err)
+	}
+	defer res.Body.Close()
+	got, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+
+	want := fmt.Sprintf("Hello, %s!", in)
+	if string(got) != want {
+		t.Errorf("want %q, but got %q", want, got)
+	}
+	cancel()
+	if err := eg.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
# やったこと
- server.goにサーバを起動する処理を移行する

# 調べたこと
- https://pkg.go.dev/net/http のドキュメントを読む。
  - ListenAndServeは指定されたアドレスとhandlerでHTTPサーバを起動する。handlerはデフォルトでnilであり、つまりDefaultServerMuxを使うということである。Handle関数とHandlerFunc関数はDefaultServerMuxにhandlerを追加する
  - https://journal.lampetty.net/entry/understanding-http-handler-in-go
  - 
