### PR TITLE
newmux関数を定義

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -1,0 +1,13 @@
+package main
+
+import "net/http"
+
+func NewMux() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = w.Write([]byte(`{"status": "ok"}`))
+	})
+
+	return mux
+}

--- a/mux_test.go
+++ b/mux_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewMux(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health", nil)
+	sut := NewMux()
+	sut.ServeHTTP(w, r)
+	resp := w.Result()
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if resp.StatusCode != http.StatusOK {
+		t.Error("want status code 200, but", resp.StatusCode)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+
+	want := `{"status": "ok"}`
+	if string(got) != want {
+		t.Errorf("want %q, but got %q", want, got)
+	}
+}


### PR DESCRIPTION
- Muxでhttpサーバにパスに対応した関数を登録できる。
- このprでは/healthエンドポイントに対応した関数を実装している
- またhttptestを使ってHandlerのテストをしている。
- 